### PR TITLE
Deactivate reqwest default features

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,7 +15,7 @@ description = "An async, macro-driven JSON-RPC client with pluggable backends."
 async-trait = "0.1"
 isahc = { version = "0.9", optional = true, features = [ "json" ] }
 jsonrpc_client_macro = { version = "0.2", path = "../macro", optional = true }
-reqwest = { version = "0.11", features = [ "json" ], optional = true }
+reqwest = { version = "0.11", default-features = false, features = [ "json" ], optional = true }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 surf = { version = "2", optional = true }


### PR DESCRIPTION
This reduces the dependency tree. Consumers can always enable specifically
the feature the need. In particular, this gives them a choice in regards
to the TLS backend that is being used.