### PR TITLE
Add `ureq` backend

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -21,6 +21,7 @@ isahc = { version = "0.9", features = [ "json" ], optional = true }
 jsonrpc_client_macro = { version = "0.3", path = "../macro", optional = true }
 reqwest = { version = "0.11", default-features = false, features = [ "json" ], optional = true }
 surf = { version = "2", optional = true }
+ureq = { version = "2.1", default-fetaures = false, features = ["json"], optional = true }
 
 [dev-dependencies]
 anyhow = "1"
@@ -53,6 +54,10 @@ required-features = [ "surf", "macros" ]
 [[example]]
 name = "isahc"
 required-features = [ "isahc", "macros" ]
+
+[[example]]
+name = "ureq"
+required-features = [ "ureq", "macros" ]
 
 [features]
 default = [ "macros" ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,13 +13,14 @@ description = "An async, macro-driven JSON-RPC client with pluggable backends."
 
 [dependencies]
 async-trait = "0.1"
-isahc = { version = "0.9", optional = true, features = [ "json" ] }
-jsonrpc_client_macro = { version = "0.3", path = "../macro", optional = true }
-reqwest = { version = "0.11", default-features = false, features = [ "json" ], optional = true }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
-surf = { version = "2", optional = true }
 url = "2"
+
+isahc = { version = "0.9", features = [ "json" ], optional = true }
+jsonrpc_client_macro = { version = "0.3", path = "../macro", optional = true }
+reqwest = { version = "0.11", default-features = false, features = [ "json" ], optional = true }
+surf = { version = "2", optional = true }
 
 [dev-dependencies]
 anyhow = "1"

--- a/lib/examples/ureq.rs
+++ b/lib/examples/ureq.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+
+#[jsonrpc_client::api]
+pub trait Math {
+    async fn subtract(&self, subtrahend: i64, minuend: i64) -> i64;
+}
+
+#[jsonrpc_client::implement(Math)]
+struct Client {
+    inner: ureq::Agent,
+    base_url: jsonrpc_client::Url,
+}
+
+impl Client {
+    fn new(base_url: String) -> Result<Self> {
+        let agent: ureq::Agent = ureq::AgentBuilder::new().build();
+
+        Ok(Self {
+            inner: agent,
+            base_url: base_url.parse()?,
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new("http://example-jsonrpc.org/".to_owned())?;
+
+    let _ = client.subtract(10, 5).await?;
+
+    Ok(())
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -70,6 +70,9 @@ pub mod surf;
 #[cfg(feature = "isahc")]
 mod isahc;
 
+#[cfg(feature = "ureq")]
+mod ureq;
+
 /// Define the API of the JSON-RPC server you want to talk to.
 ///
 /// All methods of this trait must be `async`. Additionally, the trait cannot have other items such as `const` or `type` declarations.

--- a/lib/src/ureq.rs
+++ b/lib/src/ureq.rs
@@ -1,0 +1,23 @@
+use crate::{Response, SendRequest, Url};
+use serde::de::DeserializeOwned;
+
+#[async_trait::async_trait]
+impl SendRequest for ureq::Agent {
+    type Error = ureq::Error;
+
+    async fn send_request<P>(&self, endpoint: Url, body: String) -> Result<Response<P>, Self::Error>
+    where
+        P: DeserializeOwned,
+    {
+        Ok(self
+            .post(&endpoint.to_string())
+            .send_json(ureq::json!(&body))?
+            .into_json::<Response<P>>()?)
+    }
+}
+
+impl From<ureq::Error> for crate::Error<ureq::Error> {
+    fn from(inner: ureq::Error) -> Self {
+        crate::Error::Client(inner)
+    }
+}


### PR DESCRIPTION
Add a `ureq` backend. Implementation is basically identical to the `reqwest` backend (incl. a similar example module).

- Patch one refactors the manifest file to separate optional dependencies.
- Patch two is the `ureq` stuff.