### PR TITLE
Release version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2021-07-27
+
 ### Added
 
 - `JsonRpcError` now includes the optional `data` field, defined [here](https://www.jsonrpc.org/specification#error_object).
@@ -36,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Re-export `async_trait` and `serde` dependencies from `jsonrpc_client` (https://github.com/thomaseizinger/rust-jsonrpc-client/issues/6).
+- Re-export `async_trait` and `serde` dependencies from `jsonrpc_client` (<https://github.com/thomaseizinger/rust-jsonrpc-client/issues/6>).
   This allows usage of the macros without having to add these dependencies to your own `Cargo.toml`.
 
 ## [0.3.0] - 2021-01-11
@@ -44,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This version is a complete re-write of the original `jsonrpc_client` crate.
 It features a proc-macro based approach for declaring JSON-RPC APIs which you can then interact with using a number of different backends.
 
-[Unreleased]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.7.0...HEAD
+[0.7.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ This version is a complete re-write of the original `jsonrpc_client` crate.
 It features a proc-macro based approach for declaring JSON-RPC APIs which you can then interact with using a number of different backends.
 
 [Unreleased]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.7.0...HEAD
-[0.7.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.6.0...0.7.0
+[0.7.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.6.0...0.7.0
 [0.6.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.4.0...v0.5.0

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc_client"
-version = "0.6.0"
+version = "0.7.0"
 authors = [ "Thomas Eizinger <thomas@eizinger.io>" ]
 categories = [ "web-programming::http-client", "api-bindings", "network-programming" ]
 edition = "2018"


### PR DESCRIPTION
Hi @thomaseizinger!
This PR was created in response to a manual trigger of the release workflow here: https://github.com/thomaseizinger/rust-jsonrpc-client/actions/runs/1071408414.
I've updated the changelog and bumped the versions in the manifest files in this commit: e4e9fbc5182d8a076aa7228f1e8572ac7a93313d.
Merging this PR will create a GitHub release and publish the library to crates.io!