### PR TITLE
Omit empty params in v2 request object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2021-08-20
+
+### Added
+
+- `Request` now omits `param` from serialization when empty for version 2.0 jsonrpm calls as defined [here](https://www.jsonrpc.org/specification#request_object).
+
 ## [0.7.0] - 2021-07-27
 
 ### Added
@@ -46,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This version is a complete re-write of the original `jsonrpc_client` crate.
 It features a proc-macro based approach for declaring JSON-RPC APIs which you can then interact with using a number of different backends.
 
-[Unreleased]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.7.0...HEAD
+[unreleased]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.7.0...HEAD
 [0.7.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.6.0...0.7.0
 [0.6.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.5.0...v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.1] - 2021-08-20
-
 ### Added
 
 - `Request` now omits `params` from serialization when empty for version 2.0 jsonrpm calls as defined [here](https://www.jsonrpc.org/specification#request_object).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Request` now omits `param` from serialization when empty for version 2.0 jsonrpm calls as defined [here](https://www.jsonrpc.org/specification#request_object).
+- `Request` now omits `params` from serialization when empty for version 2.0 jsonrpm calls as defined [here](https://www.jsonrpc.org/specification#request_object).
 
 ## [0.7.0] - 2021-07-27
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-authors = ["Thomas Eizinger <thomas@eizinger.io>"]
-categories = ["web-programming::http-client", "api-bindings", "network-programming"]
-description = "An async, macro-driven JSON-RPC client with pluggable backends."
-edition = "2018"
-keywords = ["jsonrpc", "macro", "http", "client"]
-license = "MIT OR Apache-2.0"
 name = "jsonrpc_client"
+version = "0.7.0"
+authors = [ "Thomas Eizinger <thomas@eizinger.io>" ]
+categories = [ "web-programming::http-client", "api-bindings", "network-programming" ]
+edition = "2018"
+keywords = [ "jsonrpc", "macro", "http", "client" ]
+license = "MIT OR Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/thomaseizinger/rust-jsonrpc-client"
-version = "0.7.1"
+description = "An async, macro-driven JSON-RPC client with pluggable backends."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = "0.1"
-isahc = {version = "0.9", optional = true, features = ["json"]}
-jsonrpc_client_macro = {version = "0.3", path = "../macro", optional = true}
-reqwest = {version = "0.11", default-features = false, features = ["json"], optional = true}
-serde = {version = "1", features = ["derive"]}
+isahc = { version = "0.9", optional = true, features = [ "json" ] }
+jsonrpc_client_macro = { version = "0.3", path = "../macro", optional = true }
+reqwest = { version = "0.11", default-features = false, features = [ "json" ], optional = true }
+serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
-surf = {version = "2", optional = true}
+surf = { version = "2", optional = true }
 url = "2"
 
 [dev-dependencies]
@@ -26,33 +26,33 @@ anyhow = "1"
 bitcoincore-rpc-json = "0.12"
 reqwest = "0.11"
 testcontainers = "0.11"
-tokio = {version = "1", features = ["macros", "rt-multi-thread"]}
+tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
 trybuild = "1"
 
 [[example]]
 name = "reqwest"
-required-features = ["reqwest", "macros"]
+required-features = [ "reqwest", "macros" ]
 
 [[example]]
 name = "custom_method"
-required-features = ["reqwest", "macros"]
+required-features = [ "reqwest", "macros" ]
 
 [[example]]
 name = "customize_path"
-required-features = ["reqwest", "macros"]
+required-features = [ "reqwest", "macros" ]
 
 [[example]]
 name = "bitcoind"
-required-features = ["reqwest", "macros"]
+required-features = [ "reqwest", "macros" ]
 
 [[example]]
 name = "surf"
-required-features = ["surf", "macros"]
+required-features = [ "surf", "macros" ]
 
 [[example]]
 name = "isahc"
-required-features = ["isahc", "macros"]
+required-features = [ "isahc", "macros" ]
 
 [features]
-default = ["macros"]
-macros = ["jsonrpc_client_macro"]
+default = [ "macros" ]
+macros = [ "jsonrpc_client_macro" ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "jsonrpc_client"
-version = "0.7.0"
-authors = [ "Thomas Eizinger <thomas@eizinger.io>" ]
-categories = [ "web-programming::http-client", "api-bindings", "network-programming" ]
+authors = ["Thomas Eizinger <thomas@eizinger.io>"]
+categories = ["web-programming::http-client", "api-bindings", "network-programming"]
+description = "An async, macro-driven JSON-RPC client with pluggable backends."
 edition = "2018"
-keywords = [ "jsonrpc", "macro", "http", "client" ]
+keywords = ["jsonrpc", "macro", "http", "client"]
 license = "MIT OR Apache-2.0"
+name = "jsonrpc_client"
 readme = "../README.md"
 repository = "https://github.com/thomaseizinger/rust-jsonrpc-client"
-description = "An async, macro-driven JSON-RPC client with pluggable backends."
+version = "0.7.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = "0.1"
-isahc = { version = "0.9", optional = true, features = [ "json" ] }
-jsonrpc_client_macro = { version = "0.3", path = "../macro", optional = true }
-reqwest = { version = "0.11", default-features = false, features = [ "json" ], optional = true }
-serde = { version = "1", features = [ "derive" ] }
+isahc = {version = "0.9", optional = true, features = ["json"]}
+jsonrpc_client_macro = {version = "0.3", path = "../macro", optional = true}
+reqwest = {version = "0.11", default-features = false, features = ["json"], optional = true}
+serde = {version = "1", features = ["derive"]}
 serde_json = "1"
-surf = { version = "2", optional = true }
+surf = {version = "2", optional = true}
 url = "2"
 
 [dev-dependencies]
@@ -26,33 +26,33 @@ anyhow = "1"
 bitcoincore-rpc-json = "0.12"
 reqwest = "0.11"
 testcontainers = "0.11"
-tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
+tokio = {version = "1", features = ["macros", "rt-multi-thread"]}
 trybuild = "1"
 
 [[example]]
 name = "reqwest"
-required-features = [ "reqwest", "macros" ]
+required-features = ["reqwest", "macros"]
 
 [[example]]
 name = "custom_method"
-required-features = [ "reqwest", "macros" ]
+required-features = ["reqwest", "macros"]
 
 [[example]]
 name = "customize_path"
-required-features = [ "reqwest", "macros" ]
+required-features = ["reqwest", "macros"]
 
 [[example]]
 name = "bitcoind"
-required-features = [ "reqwest", "macros" ]
+required-features = ["reqwest", "macros"]
 
 [[example]]
 name = "surf"
-required-features = [ "surf", "macros" ]
+required-features = ["surf", "macros"]
 
 [[example]]
 name = "isahc"
-required-features = [ "isahc", "macros" ]
+required-features = ["isahc", "macros"]
 
 [features]
-default = [ "macros" ]
-macros = [ "jsonrpc_client_macro" ]
+default = ["macros"]
+macros = ["jsonrpc_client_macro"]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -61,7 +61,6 @@
 //! jsonrpc_client = { version = "*", features = ["reqwest", "surf", "isahc"] }
 //! ```
 
-use serde::Serializer;
 #[cfg(feature = "reqwest")]
 mod reqwest;
 
@@ -132,10 +131,9 @@ pub mod export {
 #[cfg(feature = "macros")]
 pub use jsonrpc_client_macro::implement;
 
-use serde::ser::SerializeStruct;
 pub use url::Url;
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use serde_json::Value;
 use std::{
     error::Error as StdError,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -222,15 +222,18 @@ impl Serialize for Request {
     where
         S: Serializer,
     {
-        let mut s = s.serialize_struct("request", 4)?;
+        // omit v2 params if empty
+        let fields_cnt = match &self.params {
+            Params::ByName(m) if m.is_empty() => 3,
+            _ => 4,
+        };
+
+        let mut s = s.serialize_struct("Request", fields_cnt)?;
         s.serialize_field("id", &self.id)?;
         s.serialize_field("jsonrpc", &self.jsonrpc)?;
         s.serialize_field("method", &self.method)?;
-        match &self.params {
-            Params::ByName(m) if m.is_empty() => {}
-            _ => {
-                s.serialize_field("params", &self.params)?;
-            }
+        if fields_cnt == 4 {
+            s.serialize_field("params", &self.params)?;
         }
         s.end()
     }

--- a/lib/tests/ui/client_error_needs_to_implement_from.stderr
+++ b/lib/tests/ui/client_error_needs_to_implement_from.stderr
@@ -27,4 +27,4 @@ error[E0277]: the trait bound `jsonrpc_client::Error<DummyError>: From<DummyErro
    = help: the following implementations were found:
              <jsonrpc_client::Error<C> as From<JsonRpcError>>
              <jsonrpc_client::Error<C> as From<serde_json::error::Error>>
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `jsonrpc_client::implement` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This pull request removes empty params from v2 request objects if they are empty.

Resolves #45 