### PR TITLE
Release version 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2021-08-26
+
 ### Added
 
 - `Request` now omits `params` from serialization when empty for version 2.0 jsonrpm calls as defined [here](https://www.jsonrpc.org/specification#request_object).
@@ -50,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This version is a complete re-write of the original `jsonrpc_client` crate.
 It features a proc-macro based approach for declaring JSON-RPC APIs which you can then interact with using a number of different backends.
 
-[unreleased]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.7.0...HEAD
+[Unreleased]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.7.1...HEAD
+[0.7.1]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.6.0...0.7.0
 [0.6.0]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/thomaseizinger/rust-jsonrpc-client/compare/v0.5.0...v0.5.1

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc_client"
-version = "0.7.0"
+version = "0.7.1"
 authors = [ "Thomas Eizinger <thomas@eizinger.io>" ]
 categories = [ "web-programming::http-client", "api-bindings", "network-programming" ]
 edition = "2018"


### PR DESCRIPTION
Hi @thomaseizinger!
This PR was created in response to a manual trigger of the release workflow here: https://github.com/thomaseizinger/rust-jsonrpc-client/actions/runs/1168535949.
I've updated the changelog and bumped the versions in the manifest files in this commit: e8d8225389bf331373d96c064f5812b3fad4e0ba.
Merging this PR will create a GitHub release and publish the library to crates.io!